### PR TITLE
Add user agent header to curl request

### DIFF
--- a/src/PayPal/Ipn/Verifier/CurlVerifier.php
+++ b/src/PayPal/Ipn/Verifier/CurlVerifier.php
@@ -87,6 +87,7 @@ class CurlVerifier extends Verifier
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Connection: Close', 'User-Agent: MIKE182UK-IPN-LISTENER'));
 
         if ($this->forceSSL) {
             curl_setopt($ch, CURLOPT_SSLVERSION, 1);


### PR DESCRIPTION
Because of a recent change in PayPals API you will get a 403 error if you don't send a User Agent header. 
Source: https://stackoverflow.com/questions/25854207/access-denied-on-paypal-ipn-verification
