### PR TITLE
Use standard PHP functions for query string parsing 

### DIFF
--- a/spec/MessageSpec.php
+++ b/spec/MessageSpec.php
@@ -49,7 +49,7 @@ class MessageSpec extends ObjectBehavior
 
         $this->beConstructedWith($data);
 
-        $this->__toString()->shouldReturn('foo=foo%20%2B%20bar%20%28baz%29');
+        $this->__toString()->shouldReturn('foo=foo+%2B+bar+%28baz%29');
     }
 
     function it_should_accept_a_string_of_raw_post_data_for_its_data_source()
@@ -68,6 +68,6 @@ class MessageSpec extends ObjectBehavior
 
         $this->beConstructedWith($data);
 
-        $this->get('foo')->shouldReturn('foo+++bar+(baz)');
+        $this->get('foo')->shouldReturn('foo + bar (baz)');
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -50,13 +50,7 @@ class Message
      */
     public function __toString()
     {
-        $str = '';
-
-        foreach ($this->data as $k => $v) {
-            $str .= sprintf('%s=%s&', $k, rawurlencode($v));
-        }
-
-        return rtrim($str, '&');
+        return http_build_query($this->getAll(), null, '&');
     }
 
     /**
@@ -66,15 +60,7 @@ class Message
      */
     private function extractDataFromRawPostDataString($rawPostDataString)
     {
-        $data = [];
-        $keyValuePairs = preg_split('/&/', $rawPostDataString, null, PREG_SPLIT_NO_EMPTY);
-
-        foreach ($keyValuePairs as $keyValuePair) {
-            list($k, $v) = explode('=', $keyValuePair);
-
-            $data[$k] = rawurldecode($v);
-        }
-
+        parse_str($rawPostDataString, $data);
         return $data;
     }
 }


### PR DESCRIPTION
We were using the `InputStreamMessageFactory` and got failed on all requests in the live environment (Sandbox worked fine).

These are the bytes that PayPal posted to us:

```
mc_gross=34.45&protection_eligibility=Eligible&address_status=confirmed&payer_id=REDACTED&tax=0.00&address_street=Examplestreet+123&payment_date...
```

This is what Guzzle was sending to verif:

```
cmd=_notify-validate&mc_gross=39.95&protection_eligibility=Eligible&address_status=confirmed&payer_id=REDACTED&tax=0.00&address_street=Examplestreet%2B123&payment_date...
```

We fixed it by switching to the `ArrayMessageFactory`, but we'd like to bring this PR to fix it with the `InputStreamMessageFactory` too. 